### PR TITLE
Implement GitHub Pages deploy

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,51 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build site
+        run: pnpm build
+        env:
+          BASE_PATH: /${{ github.event.repository.name }}
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -142,3 +142,11 @@ When a PR is created targeting master, it will be built and deployed by Netlify.
 The URL will be indicated in a Comment in the PR.
 
 Once the PR is merged, it will automatically be released.
+
+## GitHub Pages
+
+La aplicación se despliega automáticamente en **GitHub Pages** mediante un flujo
+de trabajo de GitHub Actions. Cada vez que se realiza un push a la rama
+`main`, se ejecuta el proceso de construcción y el contenido generado en la
+carpeta `docs` se publica en la rama `gh-pages`. Tras finalizar, la dirección de
+la página se puede consultar en la pestaña de _Actions_.

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -14,6 +14,9 @@ const config = {
     alias: {
       '$/*': './src/lib/*'
     },
+    paths: {
+      base: process.env.BASE_PATH ?? ''
+    },
     adapter: adapter({
       pages: 'docs',
       fallback: '404.html'


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish the site to GitHub Pages
- allow configuring the base path via `BASE_PATH` environment variable
- document GitHub Pages deployment in the README

## Testing
- `pnpm test:unit:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68557a91d33c83248b94cc59ebbb113f