### PR TITLE
Add Angular sample

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ node_modules/**
 coverage/**
 __snapshots__/**
 snapshots.js
+examples/**

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+examples/**

--- a/examples/angular/README.md
+++ b/examples/angular/README.md
@@ -1,0 +1,13 @@
+# Angular example
+
+This directory contains an example Angular component that renders Mermaid diagrams. It shows how you can integrate the Mermaid Live Editor renderer inside an Angular project.
+
+The component expects Mermaid code and configuration as inputs and will update whenever those inputs change.
+
+Usage example (simplified `app.component.html`):
+
+```html
+<app-mermaid-view [code]="diagram" [config]="mermaidConfig"></app-mermaid-view>
+```
+
+See `mermaid-view.component.ts` for implementation details.

--- a/examples/angular/mermaid-view.component.css
+++ b/examples/angular/mermaid-view.component.css
@@ -1,0 +1,3 @@
+.mermaid-container {
+  width: 100%;
+}

--- a/examples/angular/mermaid-view.component.html
+++ b/examples/angular/mermaid-view.component.html
@@ -1,0 +1,1 @@
+<div class="mermaid-container"></div>

--- a/examples/angular/mermaid-view.component.ts
+++ b/examples/angular/mermaid-view.component.ts
@@ -1,0 +1,29 @@
+import { Component, ElementRef, Input, OnChanges } from '@angular/core';
+import mermaid from 'mermaid';
+
+@Component({
+  selector: 'app-mermaid-view',
+  templateUrl: './mermaid-view.component.html',
+  styleUrls: ['./mermaid-view.component.css']
+})
+export class MermaidViewComponent implements OnChanges {
+  /** Mermaid code to render */
+  @Input() code = '';
+  /** Mermaid configuration object */
+  @Input() config: mermaid.MermaidConfig = {} as mermaid.MermaidConfig;
+
+  constructor(private host: ElementRef<HTMLElement>) {}
+
+  ngOnChanges() {
+    this.renderDiagram();
+  }
+
+  private async renderDiagram() {
+    await mermaid.initialize(this.config);
+    const { svg } = await mermaid.render('mermaid-view', this.code);
+    const container = this.host.nativeElement.querySelector('.mermaid-container');
+    if (container) {
+      container.innerHTML = svg;
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "static/**/*.js",
     "static/**/*.json",
     "playwright.config.ts",
-    "tests/**/*.ts"
+    "tests/**/*.ts",
+    "examples/**/*.ts"
   ],
   "compilerOptions": {
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary
- add an `examples/angular` folder with a demo Angular component
- update TypeScript config to include example source
- ignore the `examples` folder when linting

## Testing
- `pnpm test:unit --run`

------
https://chatgpt.com/codex/tasks/task_e_6855ccc89c148324a5d8de509ec84d45